### PR TITLE
Add user anonymization on ban and improve database configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,12 @@ DISCORD_GUILD_ID=your_guild_id_here
 
 # Database Configuration
 DB_HOST=your_database_host
+DB_PORT=3306
 DB_NAME=your_database_name
 DB_USER=your_database_user
 DB_PASSWORD=your_database_password
 DB_DIALECT=mysql
+DB_SSL=false
 
 # Logging Configuration
 LOG_LEVEL=debug

--- a/config/ids.json
+++ b/config/ids.json
@@ -37,12 +37,7 @@
         "smashOrPassPing": "1163093412812177599",
         "bumpPing": "1044348995901861908"
     },
-    "roleAnnouncements": {
-        "1404865683354947654": {
-            "channel": "1527305838782582956",
-            "message": "🎉 Félicitations {mention}, tu as obtenu un nouveau rôle !"
-        }
-    },
+    "roleAnnouncements": {},
     "users": {
         "bumpBot": "302050872383242240",
         "dev": "551091502860730368"

--- a/database/database.js
+++ b/database/database.js
@@ -8,7 +8,9 @@ const database = process.env.DB_NAME;
 const user = process.env.DB_USER;
 const password = process.env.DB_PASSWORD;
 const host = process.env.DB_HOST;
+const port = process.env.DB_PORT;
 const dialect = process.env.DB_DIALECT || 'mysql';
+const useSsl = process.env.DB_SSL === 'true';
 
 const useSqlite = dialect === 'sqlite' || !database;
 const sequelize = useSqlite
@@ -19,8 +21,10 @@ const sequelize = useSqlite
     })
   : new Sequelize(database, user, password, {
       host: host,
+      port: port ? Number(port) : undefined,
       dialect: dialect,
       logging: false,
+      dialectOptions: useSsl ? { ssl: { require: true, rejectUnauthorized: true } } : undefined,
       pool: {
         max: 5,
         min: 0,

--- a/src/commands/moderation/ban.js
+++ b/src/commands/moderation/ban.js
@@ -1,7 +1,7 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 const { Punishments } = require('#database');
 const logger = require('#logger');
-const { ensureUserExists } = require('#utils/databaseUtils');
+const { ensureUserExists, anonymizeUser } = require('#utils/databaseUtils');
 const { logModerationAction } = require('#utils/loggerUtils');
 const { hasStaffRole } = require('#utils/permissionUtils');
 const { CommandOptionsValidator, ValidationError } = require('#utils/validators');
@@ -85,6 +85,8 @@ module.exports = {
 				logger.error('Erreur lors du ban de l\'utilisateur' + error);
 				return interaction.editReply({ content: 'Erreur lors de la tentative de ban Discord: ' + error.message, ephemeral: true });
 			}
+
+			await anonymizeUser(user);
 
 			await interaction.editReply({ content: `L'utilisateur <@${bannedUser.id}> a été banni pour la raison suivante : ${reason}`, ephemeral: true });
 

--- a/src/events/guildMember/update.js
+++ b/src/events/guildMember/update.js
@@ -106,6 +106,7 @@ async function handleBanUser(ban) {
 		// We need to register it.
 		if (staffMember) {
 			const { logModerationAction } = require('#utils/loggerUtils');
+			const { anonymizeUser } = require('#utils/databaseUtils');
 			const punisherDb = await ensureUserExists(staffMember.id, staffMember.user.username);
 
 			await Punishments.create({
@@ -115,10 +116,12 @@ async function handleBanUser(ban) {
 				type: 'ban',
 			});
 
-			// We need a context for logModerationAction that has 'guild'. 
+			// We need a context for logModerationAction that has 'guild'.
 			// The function expects 'interaction', but uses 'interaction.guild'.
 			// Pass a mock object with guild.
 			await logModerationAction({ guild: guild }, user, staffMember.user, reason, 'Ban');
+
+			await anonymizeUser(userDb);
 		} else {
 			logger.warn(`Manual ban detected for ${user.tag} but could not identify staff member. Skipping DB/Log to avoid bad data.`);
 		}

--- a/src/utils/databaseUtils.js
+++ b/src/utils/databaseUtils.js
@@ -25,4 +25,22 @@ async function ensureUserExists(discordId, username) {
     }
 }
 
-module.exports = { ensureUserExists };
+/**
+ * Anonymise un utilisateur suite à un ban : supprime les données personnelles
+ * (pseudo, identifiant Discord) tout en conservant la ligne (et donc l'historique
+ * de punitions/suggestions/etc. qui y est lié via fk_user) pour l'audit trail.
+ * @param {Model} user L'instance Sequelize du user à anonymiser.
+ */
+async function anonymizeUser(user) {
+    try {
+        await user.update({
+            discord_identifier: -user.pk_user,
+            username: 'Utilisateur banni',
+        });
+        logger.debug(`Utilisateur anonymisé suite à un ban (pk_user: ${user.pk_user})`);
+    } catch (error) {
+        logger.error(`Erreur lors de l'anonymisation de l'utilisateur (pk_user: ${user.pk_user}):`, error);
+    }
+}
+
+module.exports = { ensureUserExists, anonymizeUser };


### PR DESCRIPTION
## Summary
This PR implements user anonymization when a user is banned, ensuring personal data is removed while maintaining audit trail integrity. It also enhances database configuration flexibility with SSL and port support.

## Key Changes
- **User Anonymization**: Added `anonymizeUser()` function to replace Discord identifiers and usernames with anonymized values upon ban, preserving the user record and associated punishment history for audit purposes
- **Ban Command Integration**: Updated the ban command to call `anonymizeUser()` after banning a user
- **Event Handler Integration**: Updated the guild member update event handler to anonymize users when manual bans are detected
- **Database Configuration**: 
  - Added `DB_PORT` environment variable support (defaults to undefined for standard ports)
  - Added `DB_SSL` environment variable to enable SSL connections with proper certificate validation
  - Updated `.env.example` with new configuration options
- **Cleanup**: Removed a hardcoded role announcement entry from `ids.json`

## Implementation Details
- The anonymization strategy replaces `discord_identifier` with the negative of the user's primary key and sets `username` to 'Utilisateur banni' (Banned User)
- This approach maintains referential integrity through foreign keys while effectively removing personally identifiable information
- Database connection now supports both standard and SSL-secured connections based on environment configuration
- Error handling is in place for anonymization failures with appropriate logging

https://claude.ai/code/session_01CN7nNc41UAPaYa46SSz7Fv